### PR TITLE
feat: implement hamburger menu for login and ranking

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,24 +11,31 @@
     <div class="container">
         <header class="header">
             <h1>忍たま太郎クイズ</h1>
-            <div class="auth-section">
-                <div id="guest-section">
-                    <button id="login-btn" onclick="showLoginModal()">ログイン</button>
-                    <button id="register-btn" onclick="showRegisterModal()">新規登録</button>
-                </div>
-                <div id="user-section" style="display: none;">
-                    <span id="user-name">ユーザー名</span>
-                    <button id="logout-btn" onclick="logout()">ログアウト</button>
+            <div class="hamburger-menu">
+                <button class="hamburger-btn" onclick="toggleHamburgerMenu()">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+                <div id="hamburger-dropdown" class="hamburger-dropdown">
+                    <div id="guest-menu" class="menu-section">
+                        <button id="login-btn" onclick="showLoginModal()">ログイン</button>
+                        <button id="register-btn" onclick="showRegisterModal()">新規登録</button>
+                    </div>
+                    <div id="user-menu" class="menu-section" style="display: none;">
+                        <div class="user-info">
+                            <span id="user-name">ユーザー名</span>
+                        </div>
+                        <button id="logout-btn" onclick="logout()">ログアウト</button>
+                    </div>
+                    <div class="menu-separator"></div>
+                    <button id="ranking-btn" onclick="showRanking()">ランキング</button>
                 </div>
             </div>
         </header>
 
-        <nav class="nav-tabs">
-            <button class="tab-btn active" onclick="showTab('quiz')">クイズ</button>
-            <button class="tab-btn" onclick="showTab('ranking')">ランキング</button>
-        </nav>
 
-        <div id="quiz-tab" class="tab-content">
+        <div id="quiz-section">
             <div id="quiz-container">
                 <div id="question-section">
                     <h2 id="question"></h2>
@@ -54,8 +61,11 @@
             </div>
         </div>
 
-        <div id="ranking-tab" class="tab-content" style="display: none;">
-            <h2>ランキング</h2>
+        <div id="ranking-section" class="section" style="display: none;">
+            <div class="section-header">
+                <h2>ランキング</h2>
+                <button class="back-btn" onclick="showQuiz()">クイズに戻る</button>
+            </div>
             <div id="ranking-list">
                 <div class="loading">ランキングを読み込み中...</div>
             </div>

--- a/script.js
+++ b/script.js
@@ -46,26 +46,26 @@ async function initializeApp() {
     // フォームイベントリスナー設定
     setupFormListeners();
     
+    // ハンバーガーメニューの外側クリック時に閉じる
+    setupHamburgerMenuListeners();
+    
     // クイズ開始（エラーに関係なく必ず実行）
     startQuiz();
-    
-    // ランキング読み込み
-    loadRanking();
 }
 
 // 認証UI更新
 function updateAuthUI(user) {
-    const guestSection = document.getElementById('guest-section');
-    const userSection = document.getElementById('user-section');
+    const guestMenu = document.getElementById('guest-menu');
+    const userMenu = document.getElementById('user-menu');
     const userName = document.getElementById('user-name');
     
     if (user) {
-        guestSection.style.display = 'none';
-        userSection.style.display = 'block';
+        guestMenu.style.display = 'none';
+        userMenu.style.display = 'block';
         userName.textContent = user.email || 'ユーザー';
     } else {
-        guestSection.style.display = 'block';
-        userSection.style.display = 'none';
+        guestMenu.style.display = 'block';
+        userMenu.style.display = 'none';
     }
 }
 
@@ -73,6 +73,19 @@ function updateAuthUI(user) {
 function setupFormListeners() {
     document.getElementById('login-form').addEventListener('submit', handleLogin);
     document.getElementById('register-form').addEventListener('submit', handleRegister);
+}
+
+// ハンバーガーメニューリスナー設定
+function setupHamburgerMenuListeners() {
+    // 外側クリック時にメニューを閉じる
+    document.addEventListener('click', function(event) {
+        const hamburgerMenu = document.querySelector('.hamburger-menu');
+        const dropdown = document.getElementById('hamburger-dropdown');
+        
+        if (!hamburgerMenu.contains(event.target) && dropdown.classList.contains('show')) {
+            dropdown.classList.remove('show');
+        }
+    });
 }
 
 // ログイン処理
@@ -167,24 +180,38 @@ function closeModal(modalId) {
     document.getElementById(modalId).style.display = 'none';
 }
 
-// タブ切り替え
-function showTab(tabName) {
-    // タブボタンの状態更新
-    document.querySelectorAll('.tab-btn').forEach(btn => {
-        btn.classList.remove('active');
-    });
-    event.target.classList.add('active');
-    
-    // タブコンテンツの表示切り替え
-    document.querySelectorAll('.tab-content').forEach(content => {
-        content.style.display = 'none';
-    });
-    document.getElementById(tabName + '-tab').style.display = 'block';
-    
-    // ランキングタブの場合はデータを再読み込み
-    if (tabName === 'ranking') {
-        loadRanking();
-    }
+// ハンバーガーメニュー制御
+function toggleHamburgerMenu() {
+    const dropdown = document.getElementById('hamburger-dropdown');
+    dropdown.classList.toggle('show');
+}
+
+// セクション切り替え
+function showQuiz() {
+    document.getElementById('quiz-section').style.display = 'block';
+    document.getElementById('ranking-section').style.display = 'none';
+    // ハンバーガーメニューを閉じる
+    document.getElementById('hamburger-dropdown').classList.remove('show');
+}
+
+function showRanking() {
+    document.getElementById('quiz-section').style.display = 'none';
+    document.getElementById('ranking-section').style.display = 'block';
+    // ハンバーガーメニューを閉じる
+    document.getElementById('hamburger-dropdown').classList.remove('show');
+    // ランキングデータを読み込み
+    loadRanking();
+}
+
+// モーダル表示時にハンバーガーメニューを閉じる
+function showLoginModal() {
+    document.getElementById('login-modal').style.display = 'flex';
+    document.getElementById('hamburger-dropdown').classList.remove('show');
+}
+
+function showRegisterModal() {
+    document.getElementById('register-modal').style.display = 'flex';
+    document.getElementById('hamburger-dropdown').classList.remove('show');
 }
 
 // クイズ機能

--- a/style.css
+++ b/style.css
@@ -132,8 +132,127 @@ button:disabled {
     color: #555;
 }
 
-/* Header and Auth Section */
+/* Header and Hamburger Menu */
 .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 2px solid #e9ecef;
+    position: relative;
+}
+
+.header h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+/* Hamburger Menu */
+.hamburger-menu {
+    position: relative;
+}
+
+.hamburger-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+}
+
+.hamburger-btn span {
+    display: block;
+    height: 3px;
+    width: 100%;
+    background: #667eea;
+    border-radius: 2px;
+    transition: all 0.3s ease;
+}
+
+.hamburger-btn:hover span {
+    background: #5a6fd8;
+}
+
+.hamburger-dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: white;
+    border: 2px solid #e9ecef;
+    border-radius: 10px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+    min-width: 200px;
+    z-index: 1000;
+    display: none;
+    padding: 1rem;
+}
+
+.hamburger-dropdown.show {
+    display: block;
+}
+
+.menu-section {
+    margin-bottom: 1rem;
+}
+
+.menu-section:last-child {
+    margin-bottom: 0;
+}
+
+.menu-section button {
+    width: 100%;
+    margin-bottom: 0.5rem;
+    padding: 0.8rem 1rem;
+    font-size: 0.9rem;
+    text-align: left;
+}
+
+.menu-section button:last-child {
+    margin-bottom: 0;
+}
+
+.user-info {
+    margin-bottom: 1rem;
+    padding: 0.5rem;
+    background: #f8f9fa;
+    border-radius: 5px;
+    text-align: center;
+}
+
+#user-name {
+    font-weight: bold;
+    color: #667eea;
+}
+
+.menu-separator {
+    height: 1px;
+    background: #e9ecef;
+    margin: 1rem 0;
+}
+
+#ranking-btn {
+    background: #28a745;
+    width: 100%;
+    text-align: left;
+    padding: 0.8rem 1rem;
+    font-size: 0.9rem;
+}
+
+#ranking-btn:hover {
+    background: #218838;
+}
+
+/* Section Management */
+.section {
+    min-height: 400px;
+}
+
+.section-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -142,55 +261,20 @@ button:disabled {
     border-bottom: 2px solid #e9ecef;
 }
 
-.header h1 {
+.section-header h2 {
     margin: 0;
-    font-size: 2rem;
+    color: #333;
+    font-size: 1.8rem;
 }
 
-.auth-section button {
-    margin-left: 0.5rem;
+.back-btn {
+    background: #6c757d;
     padding: 0.5rem 1rem;
     font-size: 0.9rem;
 }
 
-#user-name {
-    margin-right: 1rem;
-    font-weight: bold;
-    color: #667eea;
-}
-
-/* Navigation Tabs */
-.nav-tabs {
-    display: flex;
-    margin-bottom: 2rem;
-    border-bottom: 2px solid #e9ecef;
-}
-
-.tab-btn {
-    background: none;
-    border: none;
-    padding: 1rem 2rem;
-    cursor: pointer;
-    font-size: 1.1rem;
-    color: #666;
-    transition: all 0.3s ease;
-    border-bottom: 3px solid transparent;
-}
-
-.tab-btn:hover {
-    color: #667eea;
-    background: #f8f9fa;
-}
-
-.tab-btn.active {
-    color: #667eea;
-    border-bottom-color: #667eea;
-    font-weight: bold;
-}
-
-/* Tab Content */
-.tab-content {
-    min-height: 400px;
+.back-btn:hover {
+    background: #5a6268;
 }
 
 /* Score Save Section */
@@ -347,21 +431,25 @@ button:disabled {
 
 /* Responsive Design */
 @media (max-width: 768px) {
-    .header {
-        flex-direction: column;
-        gap: 1rem;
-    }
-    
     .header h1 {
         font-size: 1.5rem;
     }
     
-    .nav-tabs {
-        flex-direction: column;
+    .hamburger-dropdown {
+        right: -1rem;
+        left: -1rem;
+        min-width: auto;
+        margin: 0 1rem;
     }
     
-    .tab-btn {
-        padding: 0.8rem 1rem;
+    .section-header {
+        flex-direction: column;
+        gap: 1rem;
+        text-align: center;
+    }
+    
+    .section-header h2 {
+        font-size: 1.5rem;
     }
     
     .ranking-item {


### PR DESCRIPTION
Implements hamburger menu design as requested in issue #5.

## Summary
- Replace header auth section with hamburger menu
- Move login/register and ranking to hamburger menu
- Remove quiz and ranking tab navigation
- Add responsive design and improved UX

## Test plan
- [ ] Test hamburger menu functionality
- [ ] Verify login/register works from menu
- [ ] Test ranking section navigation
- [ ] Check responsive design on mobile
- [ ] Verify quiz functionality unchanged

Generated with [Claude Code](https://claude.ai/code)